### PR TITLE
Repo hygiene: CI parity, MIT license, verification docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,13 +19,5 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e ".[dev]"
-      - name: Ruff lint
-        run: ruff check .
-      - name: Ruff format
-        run: ruff format --check .
-      - name: Mypy
-        run: mypy src tests
-      - name: Pytest
-        run: pytest
-      - name: Demo smoke
-        run: multi-bot-agentic run --goal "Summarize this repo" --provider fake --max-steps 4 --event-log /tmp/multibot-ci.sqlite
+      - name: Verify
+        run: bash scripts/check.sh

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ data/*.sqlite
 data/*.sqlite-shm
 data/*.sqlite-wal
 demo-output/
+uv.lock

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Chris Liu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -204,14 +204,16 @@ docs/                    architecture, safety, config, quickstart, demo
 ## Verification
 
 ```bash
-ruff check .
-ruff format --check .
-mypy src tests
-pytest
-scripts/run_demo.sh
+scripts/check.sh
 ```
 
-The CI workflow runs the same checks on Python 3.10, 3.11, and 3.12.
+`scripts/check.sh` runs ruff, format check, mypy, pytest, and a fake-provider smoke run with replay/report. CI runs the same script on Python 3.10, 3.11, and 3.12.
+
+For a richer local demo:
+
+```bash
+scripts/run_demo.sh
+```
 
 ## Visual Asset
 
@@ -222,3 +224,7 @@ python scripts/render_demo_gif.py
 ```
 
 The repo also keeps `docs/demo.svg` as a static architecture card.
+
+## License
+
+MIT — see [LICENSE](LICENSE).

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -11,10 +11,7 @@ python -m pip install -e ".[dev]"
 ## Verify
 
 ```bash
-ruff check .
-ruff format --check .
-mypy src tests
-pytest
+scripts/check.sh
 ```
 
 ## Run A Deterministic Demo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ description = "Deterministic multi-provider AI-agent orchestrator with Observe-D
 readme = "README.md"
 requires-python = ">=3.10"
 authors = [{ name = "Chris Liu" }]
+license = { text = "MIT" }
 dependencies = []
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- Run `scripts/check.sh` in CI so GitHub checks match local verification (lint, format, mypy, pytest, replay/report smoke).
- Add MIT `LICENSE` and declare license in `pyproject.toml`.
- Document `scripts/check.sh` as the canonical verify path in README and QUICKSTART; ignore untracked `uv.lock`.

## Context
Post-automation restore left the repo functionally correct (`scripts/check.sh` green on main) but CI only ran a partial demo smoke and docs still listed manual ruff/mypy/pytest steps. This PR closes that gap.

## Test plan
- [x] `scripts/check.sh` passes locally
- [ ] CI green on Python 3.10 / 3.11 / 3.12

## Follow-up (not in diff)
Stale `origin/phase/*` branches from the automation overwrite still point at placeholder commits; recommend deleting them after merge.


Made with [Cursor](https://cursor.com)