### PR TITLE
fix(decision): finish on step budget instead of failing with a pending tool result

### DIFF
--- a/src/multi_bot_agentic/decision.py
+++ b/src/multi_bot_agentic/decision.py
@@ -45,6 +45,19 @@ class DeterministicDecisionEngine:
             )
 
         latest_observation = observations[-1]
+        if step >= policy.max_steps - 1:
+            return Decision(
+                action="finish",
+                target=None,
+                payload={"answer": latest_observation.content.removeprefix("DONE:").strip()},
+                rationale=RationaleTrace(
+                    rule_id="model.done-or-budget",
+                    observations_used=(latest_observation.observation_id,),
+                    rejected_actions=("call_llm", "call_tool"),
+                    explanation="The step budget is exhausted, so the run finishes with the latest observation.",
+                ),
+            )
+
         if latest_observation.source.startswith("tool:"):
             return Decision(
                 action="call_llm",
@@ -86,7 +99,7 @@ class DeterministicDecisionEngine:
                 ),
             )
 
-        if latest_model_output.content.startswith("DONE:") or step >= policy.max_steps - 1:
+        if latest_model_output.content.startswith("DONE:"):
             return Decision(
                 action="finish",
                 target=None,

--- a/tests/test_decision.py
+++ b/tests/test_decision.py
@@ -37,6 +37,21 @@ def test_decision_routes_tool_request() -> None:
     assert decision.payload == {"text": "hello"}
 
 
+def test_decision_finishes_on_final_step_with_pending_tool_result() -> None:
+    """On the final step a pending tool result finishes instead of re-calling the model."""
+
+    tool_observation = Observation(source="tool:checklist", content="checklist body")
+    decision = DeterministicDecisionEngine(provider_name="fake").decide(
+        observations=(Observation(source="user", content="goal"), tool_observation),
+        step=2,
+        policy=SafetyPolicy(max_steps=3),
+    )
+
+    assert decision.action == "finish"
+    assert decision.rationale.rule_id == "model.done-or-budget"
+    assert decision.payload == {"answer": "checklist body"}
+
+
 def test_decision_sends_tool_result_back_to_model() -> None:
     """Tool results are consumed by the provider before finishing."""
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -39,6 +39,31 @@ def test_runner_succeeds_with_fake_provider(tmp_path: Path) -> None:
     assert tool_events[0].payload["tool"] == "checklist"
 
 
+def test_runner_finishes_when_budget_hit_with_pending_tool_result(tmp_path: Path) -> None:
+    """A tool result pending on the final step must finish, not fail on budget.
+
+    With ``max_steps=3`` the fake provider's flow lands a tool result on the
+    last step. Previously the ``tool.result-needs-synthesis`` rule fired before
+    the budget check, the loop ran out, and the run failed with
+    "step budget exhausted". It should finish via ``model.done-or-budget``.
+    """
+
+    log = SQLiteEventLog(tmp_path / "runs.sqlite")
+    try:
+        runner = AgentRunner(
+            provider=FakeLLMAdapter(),
+            event_log=log,
+            tools=build_default_tools(root=tmp_path),
+            safety_policy=SafetyPolicy(max_steps=3),
+        )
+        result = runner.run("Create an agent launch checklist", run_id="run-budget")
+    finally:
+        log.close()
+
+    assert result.state == RunState.SUCCEEDED
+    assert result.steps == 3
+
+
 def test_runner_cancels_before_action(tmp_path: Path) -> None:
     """A cancellation file transitions the run to cancelled."""
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The deterministic decision engine evaluated the step budget **only** inside the model-output branch (`content.startswith("DONE:") or step >= max_steps - 1`). The `tool.result-needs-synthesis` rule (and the `observe.no-model-output` rule) are checked *earlier*, so when the **final** step's latest observation was a tool result, the engine returned `call_llm`. The runner then performed that action, the `for step in range(max_steps)` loop ran out, and the run ended via `_fail(..., "step budget exhausted")` — a silent failure for a run that had effectively completed.

CI's fake-provider smoke run uses `--max-steps 5`, which needs 4 iterations to reach a `DONE:` and therefore never lands a tool result on the final step — so the bug was masked. It reproduces deterministically at `max_steps=3`.

## Fix

Evaluate the step budget at the **top** of `decide()` (right after the cancellation check). On the final step the engine now finishes via `model.done-or-budget`, using the latest observation as the answer, instead of starting another action it cannot complete. This matches the documented behavior: "If the run reaches its budget, the decision engine finishes or fails through explicit lifecycle events." The now-redundant `or step >= max_steps - 1` clause is removed from the `DONE:` branch.

## Changes
- `src/multi_bot_agentic/decision.py`: budget check moved to the top of `decide()`; `DONE:` branch simplified.
- `tests/test_runner.py`: end-to-end test at `max_steps=3` asserts `SUCCEEDED` with `steps == 3`.
- `tests/test_decision.py`: unit test — final step with a pending tool result returns `finish` / `model.done-or-budget`.

## Validation
`uv run bash scripts/check.sh` (the same gate CI runs): ruff check + ruff format + `mypy src tests` (strict) + pytest + fake-provider smoke run/replay/report.
- ruff: all checks passed
- mypy: success, 34 source files
- pytest: 24 passed (was 22; +2 new tests)
- fake-provider smoke run: `final_state: succeeded`

Confirmed both new tests fail on `main` before the fix (`finish` expected, `call_llm` produced).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-97378c9f-721e-4ee3-83c6-94b82b3122c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-97378c9f-721e-4ee3-83c6-94b82b3122c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

